### PR TITLE
[#5] Entity 별 repository 추가

### DIFF
--- a/src/main/java/studio/stew/repository/ApplicationRepository.java
+++ b/src/main/java/studio/stew/repository/ApplicationRepository.java
@@ -1,0 +1,7 @@
+package studio.stew.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import studio.stew.domain.Application;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+}

--- a/src/main/java/studio/stew/repository/CategoryRepository.java
+++ b/src/main/java/studio/stew/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package studio.stew.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import studio.stew.domain.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/studio/stew/repository/PortfolioRepository.java
+++ b/src/main/java/studio/stew/repository/PortfolioRepository.java
@@ -1,0 +1,7 @@
+package studio.stew.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import studio.stew.domain.Portfolio;
+
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+}

--- a/src/main/java/studio/stew/repository/ReviewRepository.java
+++ b/src/main/java/studio/stew/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package studio.stew.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import studio.stew.domain.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/studio/stew/repository/SportsRepository.java
+++ b/src/main/java/studio/stew/repository/SportsRepository.java
@@ -1,0 +1,7 @@
+package studio.stew.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import studio.stew.domain.Sports;
+
+public interface SportsRepository extends JpaRepository<Sports, Long> {
+}

--- a/src/main/java/studio/stew/repository/TutorRepository.java
+++ b/src/main/java/studio/stew/repository/TutorRepository.java
@@ -1,0 +1,7 @@
+package studio.stew.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import studio.stew.domain.Tutor;
+
+public interface TutorRepository extends JpaRepository<Tutor, Long> {
+}

--- a/src/main/java/studio/stew/repository/UserRepository.java
+++ b/src/main/java/studio/stew/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package studio.stew.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import studio.stew.domain.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/studio/stew/repository/WishTutorRepository.java
+++ b/src/main/java/studio/stew/repository/WishTutorRepository.java
@@ -1,0 +1,7 @@
+package studio.stew.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import studio.stew.domain.mapping.WishTutor;
+
+public interface WishTutorRepository extends JpaRepository<WishTutor, Long> {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #5

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

각 Entity 별로 JpaRepository를 상속받는 인터페이스를 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?