### PR TITLE
[#16] 튜터 삭제 API 구현

### DIFF
--- a/src/main/java/studio/stew/controller/TutorController.java
+++ b/src/main/java/studio/stew/controller/TutorController.java
@@ -38,4 +38,10 @@ public class TutorController {
         TutorResponseDto.TutorUpdateResponseDto responseDto = TutorConverter.toTutorUpdateResponseDto(tutorId);
         return DataResponseDto.of(responseDto, "튜터가 수정되었습니다.");
     }
+
+    @DeleteMapping(value = "/{tutorId}")
+    public DataResponseDto deleteTutor(@PathVariable(name="tutorId") Long tutorId) {
+        tutorService.deleteTutor(tutorId);
+        return DataResponseDto.of(null,"튜터가 삭제되었습니다");
+    }
 }

--- a/src/main/java/studio/stew/service/TutorService.java
+++ b/src/main/java/studio/stew/service/TutorService.java
@@ -91,5 +91,10 @@ public class TutorService {
             portfolioRepository.save(portfolioImg);
         }
     }
+    public void deleteTutor(Long tutorId) {
+        Tutor tutor = tutorRepository.findById(tutorId)
+                .orElseThrow(() -> new EntityNotFoundException("튜터가 없습니다."));
+        tutorRepository.delete(tutor);
+    }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #16

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

튜터 삭제 API를 구현했습니다. path parameter로 튜터id를 받아 해당 튜터를 삭제합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?