### PR TITLE
[#20] 유저가 등록한 튜터 목록 조회 API 구현

### DIFF
--- a/src/main/java/studio/stew/controller/UserController.java
+++ b/src/main/java/studio/stew/controller/UserController.java
@@ -1,0 +1,33 @@
+package studio.stew.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+import studio.stew.converter.TutorConverter;
+import studio.stew.domain.Tutor;
+import studio.stew.dto.TutorResponseDto;
+import studio.stew.response.DataResponseDto;
+import studio.stew.service.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/users")
+public class UserController {
+    private final UserService userService;
+    private final TutorConverter tutorConverter;
+    @Operation(summary = "특정 유저의 튜터 목록 조회 API",description = "특정 유저의 튜터 목록을 조회하는 API이며, 페이징을 포함합니다. query String 으로 page 번호를 주세요")
+    @GetMapping("/{userId}/tutors")
+    @Parameters({
+            @Parameter(name = "userId", description = "유저의 아이디, path variable 입니다!"),
+            @Parameter(name = "page", description = "페이지 번호, 1번이 1 페이지 입니다."),
+    })
+    public DataResponseDto<TutorResponseDto.TutorPreviewListDto> getTutorList(
+            @PathVariable Long userId,
+            @RequestParam(name = "page") Integer page) {
+        Page<Tutor> response = userService.getTutorList(userId, page-1);
+        return DataResponseDto.of(tutorConverter.toTutorPreviewListDto(response),"유저가 등록한 튜터 목록을 조회했습니다.");
+    }
+}

--- a/src/main/java/studio/stew/converter/TutorConverter.java
+++ b/src/main/java/studio/stew/converter/TutorConverter.java
@@ -1,14 +1,22 @@
 package studio.stew.converter;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
 import studio.stew.domain.Sports;
 import studio.stew.domain.Tutor;
 import studio.stew.domain.User;
 import studio.stew.dto.TutorRequestDto;
 import studio.stew.dto.TutorResponseDto;
+import studio.stew.repository.ReviewRepository;
 
 import java.time.LocalDateTime;
-
+import java.util.List;
+import java.util.stream.Collectors;
+@Component
+@RequiredArgsConstructor
 public class TutorConverter {
+    private final ReviewRepository reviewRepository;
     public static Tutor toTutor(User user, TutorRequestDto.TutorCreateRequestDto requestDto, Sports sports, String imgUrl) {
         return Tutor.builder()
                 .price(requestDto.getPrice())
@@ -36,5 +44,47 @@ public class TutorConverter {
                 .tutorId(tutorId)
                 .updatedAt(LocalDateTime.now())
                 .build();
+    }
+    public TutorResponseDto.TutorPreviewDto toTutorPreviewDto(Float score, Integer reviewCount, Tutor tutor) {
+        return TutorResponseDto.TutorPreviewDto.builder()
+                .price(tutor.getPrice())
+                .intro(tutor.getIntro())
+                .career(tutor.getCareer())
+                .name(tutor.getName())
+                .imgUrl(tutor.getImgUrl())
+                .sportName(tutor.getSports().getName())
+                .location(tutor.getLocation())
+                .reviewCount(reviewCount)
+                .score(score)
+                .build();
+    }
+    public TutorResponseDto.TutorPreviewListDto toTutorPreviewListDto(Page<Tutor> tutorList) {
+        List<TutorResponseDto.TutorPreviewDto> tutorPreViewDtoList = tutorList.stream()
+                .map(tutor -> {
+                    Float score = calculateScore(tutor);
+                    Integer reviewCount = countReviews(tutor);
+                    return toTutorPreviewDto(score, reviewCount, tutor);
+                })
+                .collect(Collectors.toList());
+
+        return TutorResponseDto.TutorPreviewListDto.builder()
+                .tutorList(tutorPreViewDtoList)
+                .isFirst(tutorList.isFirst())
+                .isLast(tutorList.isLast())
+                .totalElements(tutorList.getTotalElements())
+                .totalPage(tutorList.getTotalPages())
+                .listSize(tutorList.getSize())
+                .build();
+    }
+    public Float calculateScore (Tutor tutor) {
+        Float totalScore = 0.0f;
+        if(reviewRepository.countAllByTutor(tutor) != 0){
+            totalScore = reviewRepository.sumAllScoreByTutor(tutor.getTutorId());
+        }
+        return totalScore/countReviews(tutor);
+    }
+    public Integer countReviews (Tutor tutor) {
+        Integer countReviews = reviewRepository.countAllByTutor(tutor);
+        return countReviews;
     }
 }

--- a/src/main/java/studio/stew/dto/TutorResponseDto.java
+++ b/src/main/java/studio/stew/dto/TutorResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class TutorResponseDto {
     @Builder
@@ -25,5 +26,32 @@ public class TutorResponseDto {
         @JsonProperty("tutor_id")
         Long tutorId;
         LocalDateTime updatedAt;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TutorPreviewListDto {
+        List<TutorPreviewDto> tutorList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TutorPreviewDto {
+        String imgUrl;
+        String name;
+        String sportName;
+        String location;
+        String career;
+        String intro;
+        Float score;
+        Integer reviewCount;
+        Long price;
     }
 }

--- a/src/main/java/studio/stew/repository/ReviewRepository.java
+++ b/src/main/java/studio/stew/repository/ReviewRepository.java
@@ -1,7 +1,13 @@
 package studio.stew.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import studio.stew.domain.Review;
+import studio.stew.domain.Tutor;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Integer countAllByTutor(Tutor tutor);
+    @Query("select SUM(r.score) from Review r where r.tutor.tutorId = :tutorId")
+    Float sumAllScoreByTutor(@Param("tutorId") Long tutorId);
 }

--- a/src/main/java/studio/stew/repository/TutorRepository.java
+++ b/src/main/java/studio/stew/repository/TutorRepository.java
@@ -1,7 +1,11 @@
 package studio.stew.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import studio.stew.domain.Tutor;
+import studio.stew.domain.User;
 
 public interface TutorRepository extends JpaRepository<Tutor, Long> {
+    Page<Tutor> findAllByUser(User user, PageRequest pageRequest);
 }

--- a/src/main/java/studio/stew/service/TutorService.java
+++ b/src/main/java/studio/stew/service/TutorService.java
@@ -11,10 +11,7 @@ import studio.stew.domain.Sports;
 import studio.stew.domain.Tutor;
 import studio.stew.domain.User;
 import studio.stew.dto.TutorRequestDto;
-import studio.stew.repository.PortfolioRepository;
-import studio.stew.repository.SportsRepository;
-import studio.stew.repository.TutorRepository;
-import studio.stew.repository.UserRepository;
+import studio.stew.repository.*;
 
 import java.util.List;
 

--- a/src/main/java/studio/stew/service/UserService.java
+++ b/src/main/java/studio/stew/service/UserService.java
@@ -1,0 +1,24 @@
+package studio.stew.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import studio.stew.domain.Tutor;
+import studio.stew.domain.User;
+import studio.stew.repository.TutorRepository;
+import studio.stew.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final TutorRepository tutorRepository;
+    public Page<Tutor> getTutorList(Long userId, Integer page) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
+        Page<Tutor> TutorPage = tutorRepository.findAllByUser(user, PageRequest.of(page, 9));
+        return TutorPage;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #20

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

유저가 등록한 튜터 목록을 조회하는 api를 구현했습니다. 페이징을 포함하며, 기본으로 9개의 튜터 목록을 응답합니다. 튜터 목록이 9개보다 작을 경우 존재하는 만큼의 튜터 목록을 응답으로 보냅니다. 
스웨거로 테스트할 시 다음과 같은 응답을 받을 수 있습니다.
<img width="530" alt="image" src="https://github.com/user-attachments/assets/1f6f80f9-d39b-45b0-a7af-90d1a4738f58">

```
{
  "success": true,
  "code": 0,
  "message": "유저가 등록한 튜터 목록을 조회했습니다.",
  "data": {
    "tutorList": [
      {
        "imgUrl": null,
        "name": "김숭실",
        "sportName": "축구",
        "location": "서울시 동작구",
        "career": "경력",
        "intro": "소개",
        "score": 4,
        "reviewCount": 3,
        "price": 10000
      },
      {
        "imgUrl": null,
        "name": "김축구",
        "sportName": "축구",
        "location": "서울시 동작구",
        "career": "야호",
        "intro": "소개",
        "score": 3,
        "reviewCount": 2,
        "price": 10000
      }
    ],
    "listSize": 9,
    "totalPage": 1,
    "totalElements": 2,
    "isFirst": true,
    "isLast": true
  }
}
``` 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?